### PR TITLE
Add support for NDS joypads

### DIFF
--- a/birdseyelib/controllerInput.py
+++ b/birdseyelib/controllerInput.py
@@ -25,4 +25,8 @@ class ControllerInput:
         controller_input = ";".join(
             [bool_to_string[joypad.controls[button]] for button in joypad.controls.keys()]
         )
+        controller_analog_input = ";".join(
+            [str(joypad.analog_controls[analog_control]) for analog_control in joypad.analog_controls.keys()]
+        )
         self.client._queue_request("INP_SET;" + controller_input + "\n")
+        self.client._queue_request("INP_SET_ANALOG;" + controller_analog_input + "\n")

--- a/birdseyelib/controllerInput.py
+++ b/birdseyelib/controllerInput.py
@@ -25,8 +25,10 @@ class ControllerInput:
         controller_input = ";".join(
             [bool_to_string[joypad.controls[button]] for button in joypad.controls.keys()]
         )
-        controller_analog_input = ";".join(
-            [str(joypad.analog_controls[analog_control]) for analog_control in joypad.analog_controls.keys()]
-        )
         self.client._queue_request("INP_SET;" + controller_input + "\n")
-        self.client._queue_request("INP_SET_ANALOG;" + controller_analog_input + "\n")
+        if hasattr(joypad, "analog_controls"):
+            controller_analog_input = ";".join(
+                [str(joypad.analog_controls[analog_control])
+                 for analog_control in joypad.analog_controls.keys()]
+            )
+            self.client._queue_request("INP_SET_ANALOG;" + controller_analog_input + "\n")

--- a/birdseyelib/joypad.py
+++ b/birdseyelib/joypad.py
@@ -40,3 +40,20 @@ class SNESJoypad(Joypad):
             "A": False, "B": False, "L": False, "R": False, "X": False, "Y": False, "Up": False,
             "Down": False, "Right": False, "Left": False, "Select": False, "Start": False,
         }
+
+
+class NDSJoypad(Joypad):
+    """Controller mapping for the NDS
+    
+    The \"Power\" button is not implemented for the time being."""
+    def __init__(self):
+        super().__init__()
+        self._name = "NDS"
+        self.controls = {
+            "A": False, "B": False, "L": False, "R": False, "X": False, "Y": False, "Up": False,
+            "Down": False, "Right": False, "Left": False, "Select": False, "Start": False,
+            "LidClose": False, "LidOpen": False, "Touch": False,
+        }
+        self.analog_controls = {
+            "Mic Volume": "0", "GBA Light Sensor": "0",  "Touch X": "142", "Touch Y": "0",
+        }

--- a/docs/source/api/joypad.rst
+++ b/docs/source/api/joypad.rst
@@ -14,3 +14,6 @@ joypad
 
 .. autoclass:: birdseyelib.SNESJoypad
     :members:
+
+.. autoclass:: birdseyelib.NDSJoypad
+    :members:

--- a/exttool/ControllerInput.cs
+++ b/exttool/ControllerInput.cs
@@ -34,9 +34,9 @@ namespace BirdsEye {
         /// Execute the current input state in the emulator.
         ///</summary>
         public void ExecuteInput(ApiContainer APIs) {
-            APIs.Joypad.Set((IReadOnlyDictionary<string, bool>) _joypad.Controls!, 1);
+            APIs.Joypad.Set((IReadOnlyDictionary<string, bool>) _joypad.Controls!, _joypad.DefaultController);
             if (_joypad.ControlsAnalog != null) {
-                APIs.Joypad.SetAnalog((IReadOnlyDictionary<string, int?>) _joypad.ControlsAnalog, 1);
+                APIs.Joypad.SetAnalog((IReadOnlyDictionary<string, int?>) _joypad.ControlsAnalog, _joypad.DefaultController);
             }
         }
 

--- a/exttool/ControllerInput.cs
+++ b/exttool/ControllerInput.cs
@@ -24,6 +24,7 @@ namespace BirdsEye {
                 "NES" => new NESJoypad(),
                 "GB(C)" => new GBAndGBCJoypad(),
                 "SNES" => new SNESJoypad(),
+                "NDS" => new NDSJoypad(),
                 _ => _joypad
             };
             return new Response("");
@@ -34,6 +35,9 @@ namespace BirdsEye {
         ///</summary>
         public void ExecuteInput(ApiContainer APIs) {
             APIs.Joypad.Set((IReadOnlyDictionary<string, bool>) _joypad.Controls!, 1);
+            if (_joypad.ControlsAnalog != null) {
+                APIs.Joypad.SetAnalog((IReadOnlyDictionary<string, int?>) _joypad.ControlsAnalog, 1);
+            }
         }
 
         ///<summary>
@@ -49,6 +53,16 @@ namespace BirdsEye {
             for (int i = 0; i < _joypad.Controls!.Count; i++) {
                 key = _joypad.Controls.ElementAt(i).Key;
                 _joypad.Controls[key] = Convert.ToBoolean(newState[i]);
+            }
+            return new Response("");
+        }
+
+        public Response SetAnalogInputFromString(string str) {
+            string[] newState = str.Trim(';').Split(';');
+            string key;
+            for (int i = 0; i < _joypad.ControlsAnalog!.Count; i++) {
+                key = _joypad.ControlsAnalog.ElementAt(i).Key;
+                _joypad.ControlsAnalog[key] = Convert.ToInt32(newState[i]);
             }
             return new Response("");
         }

--- a/exttool/CustomMainForm.cs
+++ b/exttool/CustomMainForm.cs
@@ -52,6 +52,7 @@ namespace BirdsEye {
                 { "EMU_FRAME", (req) => _emulation.GetFramecount(APIs) },
                 { "INP_JOYPAD", (req) => _input.SetJoypad(req) },
                 { "INP_SET", (req) => _input.SetInputFromString(req) },
+                { "INP_SET_ANALOG", (req) => _input.SetAnalogInputFromString(req) },
                 { "MEM_ADDRESS", (req) => _memory.AddAddressesFromString(req) },
                 { "MEM_READ", (req) => _memory.MemoryOnRequest(APIs) },
             };

--- a/exttool/Joypad.cs
+++ b/exttool/Joypad.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 namespace BirdsEye {
     public class Joypad {
         public IDictionary<string, bool>? Controls;
+        public IDictionary<string, int?>? ControlsAnalog;
     }
 
     public class NESJoypad : Joypad {
@@ -29,6 +30,20 @@ namespace BirdsEye {
                 {"A", false}, {"B", false}, {"L", false}, {"R", false}, {"X", false}, {"Y", false},
                 {"Up", false}, {"Down", false}, {"Right", false}, {"Left", false},
                 {"Select", false}, {"Start", false},
+            };
+        }
+    }
+
+    public class NDSJoypad : Joypad {
+        public NDSJoypad() {
+            Controls = new Dictionary<string, bool>() {
+                {"A", false}, {"B", false}, {"L", false}, {"R", false}, {"X", false}, {"Y", false},
+                {"Up", false}, {"Down", false}, {"Right", false}, {"Left", false},
+                {"Select", false}, {"Start", false}, {"LidClose", false}, {"LidOpen", false},
+                {"Touch", false},
+            };
+            ControlsAnalog = new Dictionary<string, int?>() {
+                {"Mic Volume", 0}, {"GBA Light Sensor", 0}, {"Touch X", 142}, {"Touch Y", 0},
             };
         }
     }

--- a/exttool/Joypad.cs
+++ b/exttool/Joypad.cs
@@ -4,6 +4,7 @@ namespace BirdsEye {
     public class Joypad {
         public IDictionary<string, bool>? Controls;
         public IDictionary<string, int?>? ControlsAnalog;
+        public int? DefaultController;
     }
 
     public class NESJoypad : Joypad {
@@ -12,6 +13,7 @@ namespace BirdsEye {
                 {"A", false}, {"B", false}, {"Up", false}, {"Down", false}, {"Right", false},
                 {"Left", false}, {"Select", false}, {"Start", false},
             };
+            DefaultController = 1;
         }
     }
 
@@ -21,6 +23,7 @@ namespace BirdsEye {
                 {"A", false}, {"B", false}, {"Up", false}, {"Down", false}, {"Right", false},
                 {"Left", false}, {"Select", false}, {"Start", false},
             };
+            DefaultController = 1;
         }
     }
 
@@ -31,6 +34,7 @@ namespace BirdsEye {
                 {"Up", false}, {"Down", false}, {"Right", false}, {"Left", false},
                 {"Select", false}, {"Start", false},
             };
+            DefaultController = 1;
         }
     }
 
@@ -45,6 +49,7 @@ namespace BirdsEye {
             ControlsAnalog = new Dictionary<string, int?>() {
                 {"Mic Volume", 0}, {"GBA Light Sensor", 0}, {"Touch X", 142}, {"Touch Y", 0},
             };
+            DefaultController = null;
         }
     }
 }


### PR DESCRIPTION
This PR adds joypad support for the NDS core into the Python library and external tool.

This involves adding support for analog joypads, as the touch screen and mic are considered analog controls in the NDS BizHawk core. Also, the NDS core doesn't work if you specify a player number for joypad input, so I've added a `DefaultController` that defaults to `null` for the NDS Joypad (while remaining `1` for the existing joypads)

@SkiHatDuckie I've tested this and it works as expected from what I can tell. I'm by no means a C# developer though, so please let me know if anything there (or elsewhere in this PR) is wrong and/or needs to be changed.